### PR TITLE
Include exception instance when re-raising an caught exception

### DIFF
--- a/wrfpy/upp.py
+++ b/wrfpy/upp.py
@@ -180,7 +180,7 @@ NCAR
     except IOError as e:
       #logger.error('Unable to write itag file: %s' %filename)
       print('Unable to write itag file: %s' %filename)
-      raise  # re-raise exception
+      raise e  # re-raise exception
     #logger.debug('Leave write_itag')
 
 


### PR DESCRIPTION
Harmless, but this way it is both clear which exception is being raised, and avoid issues with static analyzers thinking the variable `e` is not used.