### PR TITLE
Avoid creating directories when testing

### DIFF
--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -1,6 +1,7 @@
 import os
 from os.path import dirname, abspath
 import unittest
+import tempfile
 from wrfpy.configuration import configuration
 
 
@@ -17,15 +18,16 @@ class end2endtest(unittest.TestCase):
         '''
         Test single radar with 2 vertical levels
         '''
-        results = {}
-        results['suitename'] = 'test'
-        results['basedir'] = './'
-        results['init'] = True
-        configuration(results)
-        # test if config.json exists
-        outfile = os.path.join(results['basedir'],
-                               results['suitename'], 'config.json')
-        self.assertEqual(os.path.exists(outfile), 1)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            results = {}
+            results['suitename'] = 'test'
+            results['basedir'] = temp_dir
+            results['init'] = True
+            configuration(results)
+            # test if config.json exists
+            outfile = os.path.join(results['basedir'],
+                                   results['suitename'], 'config.json')
+            self.assertEqual(os.path.exists(outfile), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The tests pass locally with no issues! :tada: 

However, after running the tests, you get some left-over directory (`tests/test`) and git lists it as a new directory added (i.e. this is not excluded in `.gitignore`).

I think we could use `tempfile` module (comes with Python 3.+) and just create a random temporary directory for testing instead?

Cheers
Bruno