### PR TITLE
Add validation for run_hours

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+"""
+description:    Configuration part of wrfpy
+license:        APACHE 2.0
+"""
+
+import os
+import tempfile
+import unittest
+
+import pkg_resources
+
+from wrfpy.config import config
+
+
+class TestConfig(unittest.TestCase):
+    """Tests for the config module."""
+
+    def test_load_valid_config(self):
+        """Test validation for run_hours fields in general."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "config.json")
+            cfg = self._create_basic_config(config_file)
+            cfg._check_config()
+            self.assertEqual(1, cfg.config["options_general"]["boundary_interval"])
+
+    def test_general_run_hours(self):
+        """Test validation for run_hours fields in wps."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "config.json")
+            cfg = self._create_basic_config(config_file)
+
+            # fail to validate if wps run_hours is not present
+            cfg.config["options_general"]["run_hours"] = None
+            with self.assertRaises(AssertionError):
+                cfg._check_general()
+
+    def test_wps_run_hours(self):
+        """Test validation for run_hours fields in general and wps."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "config.json")
+            cfg = self._create_basic_config(config_file)
+
+            # fail to validate if general run_hours is not present
+            cfg.config["options_wps"]["run_hours"] = None
+            with self.assertRaises(AssertionError):
+                cfg._check_wps()
+
+    def test_start_date_before_end_date_validation(self):
+        """Test validation for start date coming before end date."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "config.json")
+            cfg = self._create_basic_config(config_file)
+
+            # fail to validate if general run_hours is not present
+            cfg.config["options_general"]["date_start"], \
+            cfg.config["options_general"]["date_end"] = cfg.config["options_general"]["date_end"], \
+                                                        cfg.config["options_general"]["date_start"]
+
+            with self.assertRaises(IOError):
+                cfg._check_general()
+
+    @classmethod
+    def _create_basic_config(cls, config_file: str) -> config:
+        """Create minimal configuration file for unit config unit tests."""
+        cfg = config(wrfpy_config=config_file)
+        cfg._read_json()
+        # general
+        cfg.config["options_general"]["boundary_interval"] = 1
+        cfg.config["options_general"]["date_end"] = "2019-01-01_01"
+        cfg.config["options_general"]["date_start"] = "2019-01-01_00"
+        cfg.config["options_general"]["run_hours"] = "1"
+        # wps
+        cfg.config["options_wps"]["namelist.wps"] = cls._get_example_namelist()
+        cfg.config["options_wps"]["run_hours"] = "1"
+        # wrf
+        cfg.config["options_wrf"]["namelist.input"] = cls._get_example_namelist()
+        return cfg
+
+    @classmethod
+    def _get_example_namelist(cls) -> str:
+        resource_package = __name__
+        resource_path = '/'.join(('..', 'wrfpy', 'examples', 'namelist.wps'))
+        filename = pkg_resources.resource_filename(resource_package, resource_path)
+        return os.path.realpath(filename)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wrfpy/config.py
+++ b/wrfpy/config.py
@@ -67,7 +67,7 @@ class config:
                   'slurm_obsproc.exe', 'slurm_updatebc.exe',
                   'slurm_da_wrfvar.exe']
     keys_urbantemps = ['TBL_URB', 'TGL_URB', 'TSLB',
-                       'ah.csv', 'urban_stations']  
+                       'ah.csv', 'urban_stations']
     # create dictionaries
     config_dir = {key: '' for key in keys_dir}
     options_general = {key: '' for key in keys_general}
@@ -189,6 +189,9 @@ class config:
       message = 'start_date is after end_date'
       logger.error(message)
       raise IOError(message)
+    # check if run_hours is specified
+    run_hours = self.config['options_general']['run_hours']
+    assert run_hours, "No General run_hours specified in config file"
     # boundary interval should be an int number of hours
     assert isinstance(self.config['options_general']['boundary_interval'],
                       int), ('boundary_interval should be given as an '
@@ -209,6 +212,9 @@ class config:
       'No WPS namelist.wps specified in config file')
     # check if specified namelist.wps exist and are readable
     utils.check_file_exists(self.config['options_wps']['namelist.wps'])
+    # check if run_hours is specified
+    run_hours = self.config['options_wps']['run_hours']
+    assert run_hours, "No WPS run_hours specified in config file"
     # check if namelist.wps is in the required format and has all keys needed
     self._check_namelist_wps()
 


### PR DESCRIPTION
Spent some time trying to produce a valid `suite.rc` for Cylc (see https://gist.github.com/kinow/7131e5f989f4930432c978c70b5677ba and revisions for more). Turns out I was trying to fill only what was required in `config.json`, as I have no experience with WRF.

But without `run_hours` everything appears to work fine. But the ISO8601 period produced PTH is invalid (missing run hours). This pull request tries to address that with some `assert`s, and also unit tests to keep coverage up to required standard.

Cheers
Bruno